### PR TITLE
If the thread can't be issued, it will be a TS_WAIT_RAW

### DIFF
--- a/rtl/core/thread_select_stage.sv
+++ b/rtl/core/thread_select_stage.sv
@@ -321,7 +321,7 @@ module thread_select_stage(
 					thread_state[thread_idx] = TS_WAIT_ICACHE;
 				else if (thread_blocked[thread_idx])
 					thread_state[thread_idx] = TS_WAIT_DCACHE;
-				else if (can_issue_thread[thread_idx])
+				else if (!can_issue_thread[thread_idx])
 					thread_state[thread_idx] = TS_WAIT_RAW;
 				else if (writeback_conflict)
 					thread_state[thread_idx] = TS_WAIT_WRITEBACK_CONFLICT;


### PR DESCRIPTION
Right now, threads, which are waiting due to a dependency are showing a TS_READY within the visualizer app. This seems wrong and should come from the bug fixed within this patch.