### PR TITLE
Explicitly use and instruct to install python2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can install the remaining dependencies using the built-in package manager
 like apt-get or yum. The instructions below are for Ubuntu. You may need to
 change the package names for other distributions:
 
-    sudo apt-get install gcc g++ python perl emacs openjdk-7-jdk gtkwave imagemagick libsdl2-dev
+    sudo apt-get install gcc g++ python2.7 perl emacs openjdk-7-jdk gtkwave imagemagick libsdl2-dev
 
     git clone https://github.com/jbush001/NyuziProcessor.git
     cd NyuziProcessor

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -32,7 +32,7 @@ $(TARGET): $(BINDIR) FORCE test_verilator_version
 	cp obj_dir/Vverilator_tb $(TARGET)
 
 core/srams.inc: $(TARGET)
-	$(TARGET) +dumpmems=1 | python ../tools/misc/extract_mems.py > core/srams.inc
+	$(TARGET) +dumpmems=1 | python2 ../tools/misc/extract_mems.py > core/srams.inc
 
 # Expands AUTOWIRE/AUTOINST/etc. Requires emacs and verilog-mode module installed.
 autos: FORCE

--- a/software/apps/sceneview/make_resource_file.py
+++ b/software/apps/sceneview/make_resource_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # 
 # Copyright 2011-2015 Jeff Bush
 # 

--- a/tests/compiler/checkresult.py
+++ b/tests/compiler/checkresult.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # 
 # Copyright 2011-2015 Jeff Bush
 # 

--- a/tests/cosimulation/generate_int_arith_format.py
+++ b/tests/cosimulation/generate_int_arith_format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # 
 # Copyright 2011-2015 Jeff Bush
 # 

--- a/tests/cosimulation/generate_random.py
+++ b/tests/cosimulation/generate_random.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # 
 # Copyright 2011-2015 Jeff Bush
 # 

--- a/tests/misc/atomic/runtest.py
+++ b/tests/misc/atomic/runtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # 
 # Copyright 2011-2015 Jeff Bush
 # 

--- a/tests/misc/dflush/runtest.py
+++ b/tests/misc/dflush/runtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # 
 # Copyright 2011-2015 Jeff Bush
 # 

--- a/tests/misc/dinvalidate/runtest.py
+++ b/tests/misc/dinvalidate/runtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # 
 # Copyright 2011-2015 Jeff Bush
 # 

--- a/tests/render/render-test.mk
+++ b/tests/render/render-test.mk
@@ -91,7 +91,7 @@ debug: $(WORKDIR)/program.hex
 profile: $(WORKDIR)/program.hex FORCE
 	$(VERILATOR) +bin=$(WORKDIR)/program.hex +profile=prof.txt
 	$(OBJDUMP) -t $(WORKDIR)//program.elf > $(WORKDIR)/syms.txt
-	python ../../../tools/misc/profile.py $(WORKDIR)/syms.txt prof.txt
+	python2 ../../../tools/misc/profile.py $(WORKDIR)/syms.txt prof.txt
 
 FORCE:
 


### PR DESCRIPTION
In some systems, python2 and python3 coexist, and most of the time python3 is the default python. 
Python scripts in this project use python2. Thus, it's better to explicitly call it with version number. 
Changes here are 
+ replace python to python2 in all scripts (including in Makefiles)
+ instruct to install python2.7 in README.md