### PR TITLE
UART Overrun implementation

### DIFF
--- a/hardware/fpga/common/uart_receive.sv
+++ b/hardware/fpga/common/uart_receive.sv
@@ -67,7 +67,7 @@ module uart_receive
 				if (!rx_sync)
 				begin
 					state_nxt = STATE_READ_CHARACTER;
-					sample_count_nxt = 12;	// Scan to middle of first bit
+					sample_count_nxt = 11;	// Scan to middle of first bit
 				end
 			end
 
@@ -75,7 +75,7 @@ module uart_receive
 			begin
 				if (sample_count_ff == 0)
 				begin
-					sample_count_nxt = 8;
+					sample_count_nxt = 7;
 					if (bit_count_ff == 8)
 					begin
 						state_nxt = STATE_WAIT_START;
@@ -113,10 +113,12 @@ module uart_receive
 			sample_count_ff <= sample_count_nxt;
 			bit_count_ff <= bit_count_nxt;
 			if (do_shift)
+			begin
 				shift_register <= { rx_sync, shift_register[7:1] };
-				
+			end
+
 			if (clock_divider == 0)
-				clock_divider <= BAUD_DIVIDE;
+				clock_divider <= BAUD_DIVIDE - 1;
 			else
 				clock_divider <= clock_divider - 1;
 		end

--- a/hardware/fpga/common/uart_transmit.sv
+++ b/hardware/fpga/common/uart_transmit.sv
@@ -58,7 +58,7 @@ module uart_transmit
 				begin
 					shift_count <= shift_count - 1;
 					tx_shift <= { 1'b0, tx_shift[9:1] };
-					baud_divider <= BAUD_DIVIDE;
+					baud_divider <= BAUD_DIVIDE - 1;
 				end
 				else
 					baud_divider <= baud_divider - 1;
@@ -67,7 +67,7 @@ module uart_transmit
 			begin
 				shift_count <= 4'd10;
 				tx_shift <= { STOP_BIT, tx_char, START_BIT };
-				baud_divider <= BAUD_DIVIDE;
+				baud_divider <= BAUD_DIVIDE - 1;
 			end
 		end
 	end

--- a/tests/misc/uart_overrun/Makefile
+++ b/tests/misc/uart_overrun/Makefile
@@ -1,5 +1,5 @@
 # 
-# Copyright 2011-2015 Jeff Bush
+# Copyright 2015 Pipat Methavanitpong
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,20 +18,17 @@ TOPDIR=../../..
 
 include $(TOPDIR)/build/target.mk
 
-CFLAGS=-O3
+CFLAGS=-O3 -I../../../software/libs/libc/include -I../../../software/libs/libos/
 
-chargen.hex: chargen.c 
-	$(CC) $(CFLAGS) chargen.c -o chargen.elf ../../../software/libs/libc/crt0.o
-	$(ELF2HEX) -o chargen.hex chargen.elf
+overrun.hex: overrun.c 
+	$(CC) $(CFLAGS) overrun.c -o overrun.elf ../../../software/libs/libc/crt0.o ../../../software/libs/libc/libc.a ../../../software/libs/libos/libos.a
+	$(ELF2HEX) -o overrun.hex overrun.elf
 
-run: chargen.hex
-	$(SERIAL_BOOT) $(SERIAL_PORT) chargen.hex
-
-run-verilator: chargen.hex
-	../../../bin/verilator_model +bin=chargen.hex
+test: overrun.hex
+	../../../bin/verilator_model +bin=overrun.hex
 
 clean: FORCE
-	rm -f chargen.elf chargen.hex
+	rm -f overrun.elf overrun.hex
 
 FORCE:
 

--- a/tests/misc/uart_overrun/overrun.c
+++ b/tests/misc/uart_overrun/overrun.c
@@ -1,0 +1,73 @@
+// 
+// Copyright 2015 Pipat Methavanitpong
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+/// Check UART Overrun bit to assert and deassert properly
+/// Recommend to turn on UART Overrun print in
+///     hardware/fpga/common/uart.sv
+/// to check contents in its FIFO
+
+#include <stdio.h>
+#include <unistd.h>
+
+volatile unsigned int * const LOOPBACK_UART = (volatile unsigned int*) 0xFFFF0100;
+
+enum UartRegs
+{
+	kStatus = 0,
+	kRx = 1,
+	kTx = 2
+};
+
+void writeLoopbackUart(char ch) {
+	while ((LOOPBACK_UART[kStatus] & 1) == 0)	// Wait for ready
+		;
+	
+	LOOPBACK_UART[kTx] = ch;
+}
+
+// A UART has 7-character capacity
+const char * text = "abcdefghij";
+const int text_len = 10;
+
+int main () {
+	printf("====UART Overrun Test====\n");
+	printf("String: %s\n", text);
+	int i, j, k;
+	for (i = 1; i <= 7; i++) {
+		// Fill Rx FIFO until full and overrun
+		while ((LOOPBACK_UART[kStatus] & 4) == 0) {
+			for (j = 0; j < text_len; j++) {
+				writeLoopbackUart(text[j]);
+			}
+		}
+		// Dequeue for i characters
+		printf("%dDequeue: ", i);
+		for (k = 1; k <= i; k++) {
+			while ((LOOPBACK_UART[kStatus] & 2) == 0)
+				;
+			printf("%c", LOOPBACK_UART[kRx]);
+		}
+		printf("\n");
+
+		// Check if Overrun bit is deasserted
+		if ((LOOPBACK_UART[kStatus] & 4) == 0)
+			printf("%d:PASS\n", i);
+		else
+			printf("%d:FAIL\n", i);
+	}
+	printf("===END===\n");
+	return 0;
+}


### PR DESCRIPTION
* Overrun bit is at 1 << 2 in the UART status register
* Overrun bit is deasserted by a UART read
* UART Rx FIFO size is limited to ALMOST_FULL_THRESHOLD=7
* UART auto dequeues when the amount stored is over its threshold
* A loopback UART is added in verilator_tb at 0x100
* A UART overrun test is added in tests/misc/uart_overrun
* Correct clock dividers in rx & tx