### PR TITLE
UART Frame Error implementation

### DIFF
--- a/hardware/fpga/common/uart_receive.sv
+++ b/hardware/fpga/common/uart_receive.sv
@@ -69,8 +69,6 @@ module uart_receive
 				if (!rx_sync)
 				begin
 					state_nxt = STATE_READ_CHARACTER;
-					frame_error = 0;
-					
 					// We are at the beginning of the start bit. Next
 					// sample point is in middle of first data bit.
 					// Set divider to 1.5 times bit duration.

--- a/software/libs/libos/uart.c
+++ b/software/libs/libos/uart.c
@@ -19,7 +19,7 @@
 
 void writeUart(char ch)
 {
-	while ((REGISTERS[REG_UART_STATUS] & 1) == 0)
+	while ((REGISTERS[REG_UART_STATUS] & UART_TX_READY) == 0)
 		;	// Wait for space
 	
 	REGISTERS[REG_UART_TX] = ch;	
@@ -27,7 +27,7 @@ void writeUart(char ch)
 
 unsigned char readUart()
 {
-	while ((REGISTERS[REG_UART_STATUS] & 2) == 0)
+	while ((REGISTERS[REG_UART_STATUS] & UART_HAS_WORD) == 0)
 		;	// Wait for space
 	
 	return REGISTERS[REG_UART_RX];	

--- a/software/libs/libos/uart.c
+++ b/software/libs/libos/uart.c
@@ -27,7 +27,7 @@ void writeUart(char ch)
 
 unsigned char readUart()
 {
-	while ((REGISTERS[REG_UART_STATUS] & UART_HAS_WORD) == 0)
+	while ((REGISTERS[REG_UART_STATUS] & UART_RX_READY) == 0)
 		;	// Wait for space
 	
 	return REGISTERS[REG_UART_RX];	

--- a/software/libs/libos/uart.h
+++ b/software/libs/libos/uart.h
@@ -20,7 +20,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	
+
+#define UART_FRAME_ERR 	(1 << 3)
+#define UART_OVERRUN 	(1 << 2)
+#define UART_RX_READY 	(1 << 1)
+#define UART_TX_READY 	(1 << 0)
+
 void writeUart(char ch);
 unsigned char readUart();
 


### PR DESCRIPTION
* uart-rx: add comb logic frame error bit
* uart-rx: has 0.5 stop bit
* testbench: toggle hold low loopback uart line by writing to 0x10c
* test: append frame error test to current overrun test
* libos: define macros for uart statuses in uart.h