### PR TITLE
Improve debugging; try to fix connection if it breaks

### DIFF
--- a/tools/serial_boot/serial_boot.c
+++ b/tools/serial_boot/serial_boot.c
@@ -131,7 +131,8 @@ int writeSerialByte(int serialFd, unsigned int ch)
 
 int writeSerialLong(int serialFd, unsigned int value)
 {
-    unsigned char out[4] = {
+    unsigned char out[4] =
+    {
         value & 0xff,
         (value >> 8) & 0xff,
         (value >> 16) & 0xff,
@@ -216,7 +217,8 @@ int fixConnection(int serialFd)
     // This can help if the processor is expecting data from us
     int pingSeen = 0;
     int retry = 0;
-    while (1){
+    while (1)
+    {
         if(readSerialByte(serialFd, &ch, 25))
         {
             if (pingSeen)

--- a/tools/serial_boot/serial_boot.c
+++ b/tools/serial_boot/serial_boot.c
@@ -204,7 +204,7 @@ int fillMemory(int serialFd, unsigned int address, const unsigned char *buffer, 
 }
 int fixConnection(int serialFd)
 {
-    unsigned char ch;
+    unsigned char ch = 0;
     int charsRead = 0;
     // Clear out any waiting BAD_COMMAND bytes
     // May grab an extra byte


### PR DESCRIPTION
fixConnection uses the following strategy to try to fix a serial connection when a write fails:
-Read out any BAD_COMMAND bytes waiting
-Send pings
-If one of those pings is received, the connection is fixed

If there are more than 0 BAD_COMMAND bytes from the FPGA, fixConnection usually fails. 