### PR TITLE
Changes to provide compatibility with VCS simulator.

### DIFF
--- a/hardware/testbench/TOP.sv
+++ b/hardware/testbench/TOP.sv
@@ -1,0 +1,47 @@
+
+// TOP module for VCS simulation.
+// Compile with +initreg+random for random initialization (includes initialization to 0 and 1 -- special seeds)
+// +initreg initializes both registers and memory
+// Simulate with +initreg+<seed> to specify a seed
+// Simulate with +initreg+0 to initialize to 0
+// Simulate with +initreg+0 to initialize to 1
+
+`include "../core/defines.sv"
+
+module TOP();
+
+   logic clk;
+   logic reset;
+   
+   initial
+     begin
+        clk = '1;
+        forever #1 clk = ~clk;
+     end
+   
+   initial
+     begin
+        reset = '1;
+        #11 reset = '0;
+     end
+   
+   verilator_tb verilator_tb(.*);
+
+   // Support for FSDB dumping
+
+`ifndef FSDBFN
+ `define FSDBFN "trace.fsdb"
+`endif
+
+   initial 
+     begin: DEBUSSY_SETUP 
+`ifdef DUMP_FSDB
+        $display("Writing waveform to %s", `FSDBFN); 
+        $fsdbDumpfile(`FSDBFN); 
+        $fsdbDumpvars; 
+//      $fsdbDumpon;
+`else
+`endif
+     end
+
+endmodule

--- a/hardware/testbench/sim_ps2.sv
+++ b/hardware/testbench/sim_ps2.sv
@@ -23,8 +23,8 @@
 module sim_ps2(
     input               clk,
     input               reset,
-    output              ps2_clk,
-    output              ps2_data);
+    output logic        ps2_clk,
+    output logic        ps2_data);
 
     // This is much faster than the PS/2 controller would run normally,
     // but it makes the test take less time.

--- a/hardware/testbench/sim_sdmmc.sv
+++ b/hardware/testbench/sim_sdmmc.sv
@@ -214,7 +214,7 @@ module sim_sdmmc(
         endcase
     endtask
 
-    always_ff @(posedge sd_sclk)
+    always @(posedge sd_sclk) // fix for multiple drivers on shift_count: initial statement not compatible with always_ff according to SystemVerilog standard
     begin
         if (sd_cs_n && current_state == SD_INIT_WAIT_FOR_CLOCKS)
         begin

--- a/hardware/testbench/sim_sdram.sv
+++ b/hardware/testbench/sim_sdram.sv
@@ -103,7 +103,7 @@ module sim_sdram
     end
 
     // Bank active
-    always_ff @(posedge dram_clk)
+    always @(posedge dram_clk) // fix for multiple drivers on bank_active: initial statement not compatible with always_ff according to SystemVerilog standard
     begin
         if (cmd_precharge)
         begin
@@ -216,7 +216,7 @@ module sim_sdram
 
 
     // RAM write
-    always_ff @(posedge dram_clk)
+    always @(posedge dram_clk) // fix for multiple drivers on sdram_data -- other driver is in verilator_tb
     begin
         if (burst_active && cke_ff && burst_w)
             sdram_data[burst_address] <= dram_dq;    // Write


### PR DESCRIPTION
TOP.sv: TOP module for VCS simulation.
Note: I can supply generic VCS compile and simulate scripts if desired, let me know.

sim_ps2.sv: Added logic declaration to output ports
sim_sdmmc.sv and sim_sdram.sv: Fixed always_ff incompatibility with initial block
verilator_tb.sv: Enumerated IO sources -- for some unknown reason VCS needs it
verilator_tb.sv: Fixed logic incompatibility with inout declaration
verilator_tb.sv: Fixed SDRAM_DATA_WIDTH use before declaration
verilator_tb.sv: Fixed multiple drivers on m[1] when SIMULATE_VGA is defined
verilator_tb.sv: Added $fwrite function for dumping in VCS (uses %c for endian independence)