### PR TITLE
Added vcsbuild.pl and vcsrun.pl template scripts to support VCS.

### DIFF
--- a/build/target.mk
+++ b/build/target.mk
@@ -21,6 +21,7 @@
 
 COMPILER_DIR=/usr/local/llvm-nyuzi/bin
 BINDIR=$(TOPDIR)/bin
+BUILDDIR=$(TOPDIR)/build
 OBJ_DIR=obj
 
 CC=$(COMPILER_DIR)/clang
@@ -33,6 +34,7 @@ ELF2HEX=$(COMPILER_DIR)/elf2hex
 LLDB=$(COMPILER_DIR)/lldb
 EMULATOR=$(BINDIR)/emulator
 VERILATOR=$(BINDIR)/verilator_model
+VCSRUN=$(BUILDDIR)/vcsrun.pl
 SERIAL_BOOT=$(BINDIR)/serial_boot
 MKFS=$(BINDIR)/mkfs
 CRT0_BARE=$(TOPDIR)/software/libs/libos/crt0-bare.o

--- a/build/vcs.config
+++ b/build/vcs.config
@@ -1,0 +1,6 @@
+# specify one line for vcs and one line for verdi using the format:
+# vcs_path   => '<path-to-vcs-dir>',
+# verdi_path => '<path-to-novas-dir>',
+# See examples below:
+vcs_path   => '/tools/vcs-release/vcsK-2015.09-SP2-2-mx',
+verdi_path => '/tools/novas-release/debussy/novas,vK-2015.09-SP2-2_Verdi3',

--- a/build/vcsbuild.pl
+++ b/build/vcsbuild.pl
@@ -1,0 +1,86 @@
+#!/usr/bin/perl -w
+
+## -w for warnings
+
+use strict 'vars';
+
+use File::Basename;
+use Cwd 'abs_path';
+
+my $path = abs_path(dirname $0);
+
+##################
+## config
+
+my $config_path = "$path/../build/vcs.config";
+
+if (! -f $config_path) {
+    die "ERROR: You need to have a $config_path file for this script to work";
+}
+
+my %config = do "$config_path";
+
+##################
+## VCS version 
+
+my $vcs_path = $config{vcs_path};
+
+print "INFO: Using vcs at $vcs_path\n";
+
+if (!-d $vcs_path) {
+    die "ERROR: Path for vcs <$vcs_path> is not valid";
+}
+
+my $vcs_sva_path = "$vcs_path/packages/sva";
+
+##################
+## VERDI version 
+
+my $verdi_path = "$config{verdi_path}";
+
+if (!-d $verdi_path) {
+    die "ERROR: Path for verdi <$verdi_path> is not valid";
+}
+
+print "INFO: Using verdi at $verdi_path\n";
+
+##################
+## Compile command
+
+my $verdi_tab = "$verdi_path/5.x/share/PLI/VCS/LINUX/novas.tab";
+my $verdi_pli = "$verdi_path/5.x/share/PLI/VCS/LINUX/pli.a";
+
+my $dump_fsdb="";
+if ($ENV{DUMP_WAVEFORM}) {
+    $dump_fsdb="DUMP_FSDB";
+}
+
+my $top = "$path/../hardware/testbench/TOP.sv";
+
+if (!-f $top) {
+    die "ERROR: Couldn't find file $top";
+}
+
+my $testbench = "$path/../hardware/testbench";
+my $core = "$path/../hardware/core";
+my $common = "$path/../hardware/fpga/common";
+
+my $simv = "$path/simv";
+my $y_path = "-y $testbench -y $core -y $common -y $vcs_sva_path";
+my $inc_path = "+incdir+${core}+${vcs_sva_path}";
+my $vcs_log = "$path/vcs.log";
+
+my $command = "cd $path;vcs -o $simv -cc gcc $y_path +libext+.sv+.v+.h -sverilog $inc_path -debug +vpi +vcsd -P $verdi_tab $verdi_pli $top +define+$dump_fsdb+VCS+FSDBFN=\\\"trace.fsdb\\\"+SIMULATION +lint=all,noVCDE +error+100 +vcs+initreg+random -l $vcs_log"; 
+
+print "Executing $command\n";
+
+open COMMAND, "$command |" or die "ERROR: Couldn't execute command: $!";
+
+while (<COMMAND>) {
+    print $_;
+}
+
+close COMMAND;
+
+exit 0;
+

--- a/build/vcsrun.pl
+++ b/build/vcsrun.pl
@@ -1,0 +1,121 @@
+#!/usr/bin/perl -w
+
+## -w for warnings
+
+use strict 'vars';
+
+use File::Basename;
+use Cwd 'abs_path';
+
+my $path = abs_path(dirname $0);
+
+##################
+## config
+
+my $config_path = "$path/../build/vcs.config";
+
+if (! -f $config_path) {
+    die "ERROR: You need to have a $config_path file for this script to work";
+}
+
+my %config = do "$config_path";
+
+##################
+## VERDI version 
+
+my $verdi_path = "$config{verdi_path}";
+
+if (!-d $verdi_path) {
+    die "ERROR: Path for verdi <$verdi_path> is not valid";
+}
+
+print "INFO: Using verdi at $verdi_path\n";
+
+if (defined $ENV{'LD_LIBRARY_PATH'}) {
+    $ENV{'LD_LIBRARY_PATH'} = "$verdi_path/5.x/share/PLI/lib/LINUX:$ENV{'LD_LIBRARY_PATH'}";
+}
+else {
+    $ENV{'LD_LIBRARY_PATH'} = "$verdi_path/5.x/share/PLI/lib/LINUX";
+}
+
+##################
+## Simulation command
+
+## Dump multidimensional arrays 
+$ENV{'NOVAS_FSDB_MDA'} = "1"; ## does both packed and unpacked
+##$ENV{'NOVAS_FSDB_MDA_PACKONLY'} = "1";
+
+# +randomize=*enable*             | Randomize initial register and memory values. Used to verify reset handling. Defaults to on.
+# +randseed=*seed*                | If randomization is enabled, set the seed for the random number generator.
+
+## $#ARGV is -1 when no arguments are passed
+## $#ARGV+1 is the total number passed
+
+my $t1 = time;
+
+my $randomize_en = 1; ## default is enabled
+my $randseed = $t1;
+
+for (my $idx = 0; $idx <= $#ARGV; $idx++) {
+    my $arg = $ARGV[$idx];
+    if ($arg =~ /\+randomize/) {
+	if ($arg =~ /\+randomize=e.*/ || $arg =~ /\+randomize=1/) {
+	    $randomize_en = 1; 
+	}
+	elsif ($arg =~ /\+randomize=d.*/ || $arg =~ /\+randomize=0/) {
+	    $randomize_en = 0; 
+	}
+	else {
+	    $randomize_en = 1; 
+	    print "INFO: Unexpected $arg value. Options are +randomize=enable|1|disable|0. Ignoring...\n";
+	}
+    }
+    elsif ($arg =~ /\+randseed/) {
+	if ($arg =~ /\+randseed=([0-9]+)/) {
+	    my $val = $1;
+	    if ($val == 0 || $val == 1) {
+		$randseed = $t1;
+		print "INFO: Unexpected $arg value. Options are +randseed=<seed>, seed cannot be 0 or 1. Ignoring...\n";
+	    }
+	    else {
+		$randseed = $val; 
+	    }
+	}
+	else {
+	    $randseed = $t1;
+	    print "INFO: Unexpected $arg value. Options are +randseed=<seed>. Ignoring...\n";
+	}
+    }
+}
+
+print "INFO: Random seed is $randseed\n";
+
+my $vcs_init_reg;
+if ($randomize_en) {
+    printf "INFO: randomizing the initial values of registers and SRAMs.\n";
+    $vcs_init_reg = "+vcs+init+$randseed";
+}
+else {
+    printf "INFO: zeroing the initial values of registers and SRAMs.\n";
+    $vcs_init_reg = "+vcs+init+0";
+}
+
+my $simv = "$path/simv";
+my $command = "$simv $vcs_init_reg +vcs+lic+wait @ARGV";
+
+if (!-f $simv) {
+    die "ERROR: You must run sssim.pl on the directory where your $simv executable is located";
+}
+
+print "Executing $command\n";
+
+open COMMAND, "$command |" or die "ERROR: Couldn't execute command: $!";
+
+while (<COMMAND>) {
+    print $_;
+}
+
+close COMMAND;
+
+exit 0;
+

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+BUILDDIR=../build
+VCSBUILD=$(BUILDDIR)/vcsbuild.pl
+
 BINDIR=../bin
 TARGET=$(BINDIR)/verilator_model
 MIN_VERILATOR_VERSION=880
@@ -34,6 +37,9 @@ $(TARGET): $(BINDIR) test_verilator_version
 	verilator $(VERILATOR_OPTIONS) --cc testbench/verilator_tb.sv --exe testbench/verilator_main.cpp
 	make CXXFLAGS=-Wno-parentheses-equality OPT_FAST="-Os"  -C obj/ -f Vverilator_tb.mk Vverilator_tb
 	cp obj/Vverilator_tb $(TARGET)
+
+vcsbuild:
+	$(VCSBUILD)
 
 # Verilator usually doesn't compile the FPGA project files, but this
 # will run it in lint-only mode to catch syntax errors or mismatches
@@ -71,3 +77,5 @@ $(BINDIR):
 clean:
 	rm -rf obj/*
 	rm -f $(TARGET)
+	rm -rf $(BUILDDIR)/csrc $(BUILDDIR)/simv.daidir
+	rm -f $(BUILDDIR)/simv

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -77,3 +77,45 @@ format in the current working directory. This can be with a waveform
 viewer like [GTKWave](http://gtkwave.sourceforge.net/).
 Waveform files get big quickly. Even running a minute of simulation can
 produce hundreds of megabytes of trace data.
+
+Support for VCS:
+
+Template scripts have been added to support building and running with VCS.
+The VCS scripts are located in the build/ directory.
+
+vcsbuild.pl requires no arguments and builds the model. It will create an
+executable named simv and two support directories csrc and simv.daidir all located
+in the build/ directory. vcsbuild.pl uses TOP.sv in the hardware/testbench
+directory as the testbench top. TOP.sv in the VCS build is analogous to
+verilator_main.cpp in the verilator build.
+
+vcsrun.pl will run simulation. It accepts plus arguments in the same way as the
+verilor_model. Any plus argument that is Verilog specific should work. It also
+supports +randomize=*\[1\|0\]* and +randseed=*seed*
+
+vcs.config in the build/ directory is used to configure the paths for VCS and Verdi
+for both scripts (edit the file according to your site's installation).
+
+The Makefile in the hardware/ directory can be used to build the VCS model by
+executing:
+
+% make vcsbuild
+
+Waveform dumping can be enabled by executing:
+
+% make clean
+% DUMP_WAVEFORM=1 make vcsbuild
+
+If waveform dumping is enabled in VCS, the simulator writes a file called
+`trace.fsdb` which can be opened with Verdi.
+
+Several apps can be found in the software/apps/ directory: doom, hello_world,
+mandelbrot, plasma, quakeview, rotozoom, sceneview. The Makefile for doom,
+hello_world, mandelbrot, quakeview, and sceneview support simulation with
+Verilator by executing:
+
+% make verirun
+
+Similarly, the same apps support simulation with VCS by executing:
+
+% make vcsrun

--- a/hardware/testbench/TOP.sv
+++ b/hardware/testbench/TOP.sv
@@ -6,7 +6,7 @@
 // Simulate with +initreg+0 to initialize to 0
 // Simulate with +initreg+0 to initialize to 1
 
-`include "../core/defines.sv"
+`include "defines.sv"
 
 module TOP();
 

--- a/software/apps/doom/Makefile
+++ b/software/apps/doom/Makefile
@@ -99,6 +99,10 @@ debug: $(OBJ_DIR) $(HEX_FILE) fsimage.bin
 verirun: $(OBJ_DIR)  $(HEX_FILE) fsimage.bin
 	$(VERILATOR) +bin=obj/doom.hex +block=fsimage.bin
 
+vcsrun: $(OBJ_DIR)  $(HEX_FILE) fsimage.bin
+	@rm -f $(OBJ_DIR)/output.bin output.png
+	$(VCSRUN) +bin=obj/doom.hex +block=fsimage.bin
+
 fpgarun: $(HEX_FILE)
 	$(SERIAL_BOOT) $(SERIAL_PORT) $(HEX_FILE) fsimage.bin
 

--- a/software/apps/hello_world/Makefile
+++ b/software/apps/hello_world/Makefile
@@ -36,6 +36,9 @@ run: $(HEX_FILE)
 verirun: $(HEX_FILE)
 	$(VERILATOR) +bin=$(HEX_FILE)
 
+vcsrun: $(HEX_FILE)
+	$(VCSRUN) +bin=$(HEX_FILE)
+
 clean:
 	rm -rf $(OBJ_DIR)
 

--- a/software/apps/mandelbrot/Makefile
+++ b/software/apps/mandelbrot/Makefile
@@ -38,6 +38,11 @@ verirun: $(HEX_FILE)
 	$(VERILATOR) +memdumpfile=$(OBJ_DIR)/output.bin +memdumpbase=0x200000 +memdumplen=0x12C000 +bin=$(HEX_FILE)
 	@convert -depth 8 -size 640x480 rgba:$(OBJ_DIR)/output.bin output.png
 
+vcsrun: $(OBJ_DIR)/mandelbrot.hex
+	@rm -f $(OBJ_DIR)/output.bin output.png
+	$(VCSRUN) +memdumpfile=$(OBJ_DIR)/output.bin +memdumpbase=0x200000 +memdumplen=0x12C000 +bin=$(OBJ_DIR)/mandelbrot.hex
+	@convert -depth 8 -size 640x480 rgba:$(OBJ_DIR)/output.bin output.png
+
 krun: fsimage.bin
 	$(EMULATOR) -b fsimage.bin -f 640x480 $(TOPDIR)/software/kernel/kernel.hex
 

--- a/software/apps/quakeview/Makefile
+++ b/software/apps/quakeview/Makefile
@@ -63,6 +63,11 @@ verirun: $(HEX_FILE) fsimage.bin
 	$(VERILATOR) +memdumpfile=$(OBJ_DIR)/output.bin +memdumpbase=0x200000 +memdumplen=0x12C000 +bin=$(HEX_FILE) +block=fsimage.bin
 	@convert -depth 8 -size 640x480 rgba:$(OBJ_DIR)/output.bin output.png
 
+vcsrun: $(HEX_FILE) fsimage.bin
+	@rm -f $(OBJ_DIR)/output.bin output.png
+	$(VCSRUN) +memdumpfile=$(OBJ_DIR)/output.bin +memdumpbase=0x200000 +memdumplen=0x12C000 +bin=$(HEX_FILE) +block=fsimage.bin
+	@convert -depth 8 -size 640x480 rgba:$(OBJ_DIR)/output.bin output.png
+
 fsimage.bin: pak0.pak
 	$(MKFS) $@ pak0.pak
 

--- a/software/apps/sceneview/Makefile
+++ b/software/apps/sceneview/Makefile
@@ -62,6 +62,11 @@ verirun: $(HEX_FILE)
 	$(VERILATOR) +memdumpfile=$(OBJ_DIR)/output.bin +memdumpbase=200000 +memdumplen=12C000 +bin=$(HEX_FILE) +block=fsimage.bin
 	@convert -depth 8 -size 640x480 rgba:$(OBJ_DIR)/output.bin output.png
 
+vcsrun: $(HEX_FILE)
+	@rm -f $(OBJ_DIR)/output.bin output.png
+	$(VCSRUN) +memdumpfile=$(OBJ_DIR)/output.bin +memdumpbase=200000 +memdumplen=12C000 +bin=$(HEX_FILE) +block=fsimage.bin
+	@convert -depth 8 -size 640x480 rgba:$(OBJ_DIR)/output.bin output.png
+
 fpgarun: $(HEX_FILE)
 	$(SERIAL_BOOT) $(SERIAL_PORT) $(HEX_FILE) fsimage.bin
 


### PR DESCRIPTION
build/target.mk: Added path to vcsrun.pl
build/vcs.config: New file to specify paths to VCS and Verdi tool installations
build/vcsbuild.pl: Template script to build simulator using VCS
build/vcsrun.pl: Template script to run simulator built with VCS
hardware/Makefile: Added vcsbuild target to run vcsbuild.pl
hardware/README.md: Added VCS support documentation
hardware/testbench/TOP.sv: Minor change to support template scripts
software/apps/doom/Makefile: Added vcsrun target to run vcsrun.pl
software/apps/hello_world/Makefile: Added vcsrun target to run vcsrun.pl
software/apps/mandelbrot/Makefile: Added vcsrun target to run vcsrun.pl
software/apps/quakeview/Makefile: Added vcsrun target to run vcsrun.pl
software/apps/sceneview/Makefile: Added vcsrun target to run vcsrun.pl

vcsbuild.pl and vcsrun.pl could be placed in the bin/ directory but since it is not part of the repository 
I place them instead in the build/ directory. 