### PR TITLE
Use dedicated NUM_ENTRIES parameter for I$ TLB.

### DIFF
--- a/hardware/core/ifetch_tag_stage.sv
+++ b/hardware/core/ifetch_tag_stage.sv
@@ -233,7 +233,7 @@ module ifetch_tag_stage
     end
 
     tlb #(
-        .NUM_ENTRIES(`DTLB_ENTRIES),
+        .NUM_ENTRIES(`ITLB_ENTRIES),
         .NUM_WAYS(`TLB_WAYS)
     ) itlb(
         .lookup_en(cache_fetch_en),


### PR DESCRIPTION
By default DTLB_ENTRIES == ITLB_ENTRIES, so it wouldn't change anything. Issue arose when playing with different number of D/I TLB entries.