### PR TITLE
Add logic data type to perf_event_count port

### DIFF
--- a/hardware/core/performance_counters.sv
+++ b/hardware/core/performance_counters.sv
@@ -29,7 +29,7 @@ module performance_counters
     input                                               reset,
     input [NUM_EVENTS - 1:0]                            perf_events,
     input [NUM_COUNTERS - 1:0][EVENT_IDX_WIDTH - 1:0]   perf_event_select,
-    output [NUM_COUNTERS - 1:0][63:0]                   perf_event_count);
+    output logic[NUM_COUNTERS - 1:0][63:0]              perf_event_count);
 
     always_ff @(posedge clk, posedge reset)
     begin : update


### PR DESCRIPTION
Output port perf_event_count has no data type defined and will default to
'wire logic', which can't be driven using procedural assignments.