### PR TITLE
Fixing width cast warnings that pop-up when running with NUM_CORES > 1

### DIFF
--- a/tests/unit/test_control_registers.sv
+++ b/tests/unit/test_control_registers.sv
@@ -624,53 +624,53 @@ module test_control_registers(input clk, input reset);
                 172:
                 begin
                     write_creg(CR_SUSPEND_THREAD, 32'h5);
-                    assert(cr_suspend_thread == 4'h0);
-                    assert(cr_resume_thread == 4'h0);
+                    assert(cr_suspend_thread == 'h0);
+                    assert(cr_resume_thread == 'h0);
                 end
 
                 // wait cycle
                 173:
                 begin
-                    assert(cr_suspend_thread == 4'h0);
-                    assert(cr_resume_thread == 4'h0);
+                    assert(cr_suspend_thread == 'h0);
+                    assert(cr_resume_thread == 'h0);
                 end
 
                 174:
                 begin
-                    assert(cr_suspend_thread == 4'h5);
-                    assert(cr_resume_thread == 4'h0);
+                    assert(cr_suspend_thread == 'h5);
+                    assert(cr_resume_thread == 'h0);
                 end
 
                 175:
                 begin
-                    assert(cr_suspend_thread == 4'h0);
-                    assert(cr_resume_thread == 4'h0);
+                    assert(cr_suspend_thread == 'h0);
+                    assert(cr_resume_thread == 'h0);
                 end
 
                 176:
                 begin
                     write_creg(CR_RESUME_THREAD, 32'ha);
-                    assert(cr_suspend_thread == 4'h0);
-                    assert(cr_resume_thread == 4'h0);
+                    assert(cr_suspend_thread == 'h0);
+                    assert(cr_resume_thread == 'h0);
                 end
 
                 // wait cycle
                 177:
                 begin
-                    assert(cr_suspend_thread == 4'h0);
-                    assert(cr_resume_thread == 4'h0);
+                    assert(cr_suspend_thread == 'h0);
+                    assert(cr_resume_thread == 'h0);
                 end
 
                 178:
                 begin
-                    assert(cr_suspend_thread == 4'h0);
-                    assert(cr_resume_thread == 4'ha);
+                    assert(cr_suspend_thread == 'h0);
+                    assert(cr_resume_thread == 'ha);
                 end
 
                 179:
                 begin
-                    assert(cr_suspend_thread == 4'h0);
-                    assert(cr_resume_thread == 4'h0);
+                    assert(cr_suspend_thread == 'h0);
+                    assert(cr_resume_thread == 'h0);
                 end
 
                 ////////////////////////////////////////////////////////////

--- a/tests/unit/test_l2_cache.sv
+++ b/tests/unit/test_l2_cache.sv
@@ -95,7 +95,7 @@ module test_l2_cache(input clk, input reset);
         begin
             // default values
             l2i_request_valid <= '0;
-            if (l2i_request_valid)
+            if (l2i_request_valid != '0)
                 assert(l2_ready[0]);
 
             unique case (state)


### PR DESCRIPTION
**test_l2_cache.sv** - Adding explicit comparison for l2i_request_valid, as for NUM_CORES > 1, its width will be greater than 1 bit.

**test_control_registers.sv** - Removing fixed width cast on cr_suspend_thread and cr_resume_thread asserts, since their size will change based on NUM_CORES.